### PR TITLE
Optionally allow to use Mermaid graphs from external file

### DIFF
--- a/convert/converter.html
+++ b/convert/converter.html
@@ -11,7 +11,8 @@
       startOnLoad: true,
       cloneCssStyles: true,
       flowchart: {
-        htmlLabels: false
+        htmlLabels: false,
+        useMaxWidth:false
       },
     });
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var join         = require('path').join;
 var readFileSync = require('fs').readFileSync;
+var resolve      = require('url').resolve;
 
 var phantom = require('phantom');
 var Q       = require('q');
@@ -8,12 +9,14 @@ var Q       = require('q');
 module.exports = {
   blocks: {
     mermaid: {
-      process: function(blk) {
-        var body = blk.body;
+      process: function(block) {
+        var body = block.body;
 
-        var args = block.args;
-        if(args.length)
-          body = readFileSync(args[0], 'utf8');
+        var src = block.kwargs.src;
+        {
+          var path = decodeURI(resolve(this.ctx.file.path, src));
+          body = readFileSync(path, 'utf8');
+        }
 
         return processBlock(body);
       }

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = {
         var body = block.body;
 
         var src = block.kwargs.src;
+        if(src)
         {
           var path = decodeURI(resolve(this.ctx.file.path, src));
           body = readFileSync(path, 'utf8');

--- a/index.js
+++ b/index.js
@@ -1,32 +1,39 @@
-var phantom = require("phantom");
-var Q = require('q');
-var path = require('path');
+var join         = require('path').join;
+var readFileSync = require('fs').readFileSync;
+
+var phantom = require('phantom');
+var Q       = require('q');
 
 
 module.exports = {
   blocks: {
     mermaid: {
       process: function(blk) {
-        return processBlock(blk);
+        var body = blk.body;
+
+        var args = block.args;
+        if(args.length)
+          body = readFileSync(args[0], 'utf8');
+
+        return processBlock(body);
       }
     }
   }
 };
 
-function processBlock(block) {
-  return convertToSvg(block.body)
+function processBlock(body) {
+  return convertToSvg(body)
       .then(function (svgCode) {
           return svgCode.replace(/mermaidChart1/g, getId());
       });
 }
 
 function convertToSvg(mermaidCode) {
-
   var deferred = Q.defer();
   phantom.create(function (ph) {
     ph.createPage(function (page) {
 
-      var htmlPagePath = path.join(__dirname, 'convert/converter.html');
+      var htmlPagePath = join(__dirname, 'convert/converter.html');
 
       page.open(htmlPagePath, function (status) {
         page.evaluate(


### PR DESCRIPTION
If the Mermaid block has an argument, it's used as the relative path to the file whose content will be rendered instead of the content of block, similar to how html script tags work. This implements issue #7.
