### PR TITLE
Updated version of phantom

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "q": "1.1.2",
-    "phantom": "0.8.0",
+    "phantom": "^0.8.3",
     "phantomjs": "~1.9.18"
   },
   "license": "Apache 2"


### PR DESCRIPTION
Phantom v0.8.3 allow to have spaces on the path of the PhantomJS binary
