### PR TITLE
Remove hardcoded fonts

### DIFF
--- a/convert/assets/mermaid.css
+++ b/convert/assets/mermaid.css
@@ -81,7 +81,6 @@ text.actor {
 .noteText {
   fill: black;
   stroke: none;
-  font-family: 'trebuchet ms', verdana, arial;
   font-size: 14px;
 }
 /** Section styling */
@@ -251,7 +250,6 @@ text.actor {
 
 */
 text {
-  font-family: 'trebuchet ms', verdana, arial;
   font-size: 14px;
 }
 


### PR DESCRIPTION
Fonts were hardcoded to a set of Microsoft fonts that happen to render poorly on Macs, especially at the small size at which fonts are used in sequence diagrams.
## Before

![screen shot 2015-11-17 at 11 31 27 am](https://cloud.githubusercontent.com/assets/51505/11222984/79b76aa0-8d3b-11e5-9b0c-0a809c521ff1.png)
## After

![screen shot 2015-11-17 at 11 31 38 am](https://cloud.githubusercontent.com/assets/51505/11222993/827a5a8a-8d3b-11e5-9e18-79220028317b.png)
